### PR TITLE
Refactor vending system to use config driven loops

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -1,299 +1,66 @@
---CLIENT
+-- CLIENT
 ESX = nil
 
 Citizen.CreateThread(function()
-	while ESX == nil do
-		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-		Citizen.Wait(10)
-	end
+    while ESX == nil do
+        TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+        Citizen.Wait(10)
+    end
 end)
 
+local player = PlayerPedId()
 
+local function openVendingMenu(machineType)
+    local machine = Config.Machines[machineType]
+    if not machine then return end
 
+    local menu = {
+        { id = 1, header = machine.label, txt = '' }
+    }
 
-local player = PlayerPedId(-1)
+    for i, item in ipairs(machine.items) do
+        menu[#menu+1] = {
+            id = i + 1,
+            header = ("%s %s$"):format(item.label, item.price),
+            txt = '',
+            params = {
+                event = 'mr-vending:buyItem',
+                args = { item = item.item, price = item.price }
+            }
+        }
+    end
+
+    TriggerEvent('nh-context:sendMenu', menu)
+end
 
 Citizen.CreateThread(function()
-   local drinkvendings = { 
-        `prop_vend_soda_01`,
-        `prop_vend_soda_02`,
-        `prop_vend_water_01`,
-    }
-    exports[Config.Target]:AddTargetModel(drinkvendings, {
-        options = {
-            {
-                event = "mr-vending:sodamach",
-                icon = "fas fa-glass-whiskey",
-                label = "Напитки",
+    for machineType, machine in pairs(Config.Machines) do
+        exports[Config.Target]:AddTargetModel(machine.models, {
+            options = {
+                {
+                    event = 'mr-vending:open:' .. machineType,
+                    icon = machine.icon,
+                    label = machine.label
+                }
             },
-        },
-        job = {'all'},
-        distance = 2
-    })
-    local foodvendings = { 
-        `prop_vend_snak_01`,
-        `prop_vend_snak_01_tu`,    
-    }
-    exports[Config.Target]:AddTargetModel(foodvendings, {
-        options = {
-            {
-                event = "mr-vending:vendingmach",
-                icon = "fas fa-hotdog",
-                label = "Вендинг машина",
-            },
-        },
-        job = {'all'},
-        distance = 2
-    })
-    local coffeevendings = { 
-        `prop_vend_coffe_01`,
-    }
-    exports[Config.Target]:AddTargetModel(coffeevendings, {
-        options = {
-            {
-                event = "mr-vending:coffemach",
-                icon = "fas fa-mug-hot",
-                label = "Кафе машина",
-            },
-        },
-        job = {'all'},
-        distance = 2
-    })
+            job = { 'all' },
+            distance = 2
+        })
 
-    local vodu = { 
-        `prop_watercooler_dark`,
-        `prop_watercooler`,
-        `watercooler_bottle001`,
-        `prop_vend_water_01`,
-    }
-    exports[Config.Target]:AddTargetModel(vodu, {
-        options = {
-            {
-                event = "mr-vending:waterdis",
-                icon = "fas fa-water",
-                label = "Диспенсер за вода",
-            },
-        },
-        job = {'all'},
-        distance = 2
-    })
-
-    Citizen.Wait(0)
+        RegisterNetEvent('mr-vending:open:' .. machineType)
+        AddEventHandler('mr-vending:open:' .. machineType, function()
+            openVendingMenu(machineType)
+        end)
+    end
 end)
 
+RegisterNetEvent('mr-vending:buyItem')
+AddEventHandler('mr-vending:buyItem', function(data)
+    local item = data.item
+    local price = data.price
 
-
-
-RegisterNetEvent('mr-vending:sodamach', function()
-    TriggerEvent('nh-context:sendMenu', {
-        {
-            id = 1,
-            header = "Машина за соди",
-            txt = ""
-        },
-        {
-            id = 2,
-            header = "Количка 7$",
-            txt = "Derby или нищо!",
-            params = {
-                event = "sodaitem1",
-                args = {
-                    number = 1,
-                    id = 2
-                }
-            }
-        },
-        {
-            id = 3,
-            header = "Водичка 5$",
-            txt = "Хидратацията е много важно нещо",
-            params = {
-                event = "sodaitem2",
-                args = {
-                    number = 2,
-                    id = 3
-                }
-            }
-        },
-        {
-            id = 4,
-            header = "Енергиина напитка 12$",
-            txt = "Hell-че брат",
-            params = {
-                event = "sodaitem3",
-                args = {
-                    number = 3,
-                    id = 4
-                }
-            }
-        },
-    })
-end)
-
-RegisterNetEvent('mr-vending:vendingmach', function()
-    TriggerEvent('nh-context:sendMenu', {
-        {
-            id = 1,
-            header = "Вендинг машина",
-            txt = ""
-        },
-        {
-            id = 2,
-            header = "Пакетиран сандвич 5$",
-            txt = "Старичък и леко изсъхнал",
-            params = {
-                event = "vendingitem1",
-                args = {
-                    number = 1,
-                    id = 2
-                }
-            }
-        },
-        {
-            id = 3,
-            header = "Фафла 5$",
-            txt = "Кат' на Криско, ама по-хубави",
-            params = {
-                event = "vendingitem2",
-                args = {
-                    number = 2,
-                    id = 3
-                }
-            }
-        },
-        {
-            id = 4,
-            header = "Сливенски поничка 5$",
-            txt = "Сладки и мазни, като...",
-            params = {
-                event = "vendingitem3",
-                args = {
-                    number = 3,
-                    id = 4
-                }
-            }
-        },
-    })
-end)
-
-RegisterNetEvent('mr-vending:coffemach', function()
-    TriggerEvent('nh-context:sendMenu', {
-        {
-            id = 1,
-            header = "Машина за кафе",
-            txt = ""
-        },
-        {
-            id = 2,
-            header = "Кафенце 5$",
-            txt = "Абе става, като за от машина",
-            params = {
-                event = "coffeeitem",
-                args = {
-                    number = 1,
-                    id = 2
-                }
-            }
-        },
-    })
-end)
-
-RegisterNetEvent('mr-vending:waterdis', function()
-    TriggerEvent('nh-context:sendMenu', {
-        {
-            id = 1,
-            header = "Диспенсер за вода",
-            txt = ""
-        },
-        {
-            id = 2,
-            header = "Водичка 5$",
-            txt = "Абе става, като за от машина",
-            params = {
-                event = "wateritem",
-                args = {
-                    number = 1,
-                    id = 2
-                }
-            }
-        },
-    })
-end)
-
----------------------Евенти
-
-RegisterNetEvent("vendingitem1")
-AddEventHandler("vendingitem1", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
+    TaskPlayAnim(player, 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@', 'machinic_loop_mechandplayer', 1.0, -1.0, -1, 1, 0, false, false, false)
     Citizen.Wait(2000)
     ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","sandwich",5)
+    TriggerServerEvent('mr-vending:server:buyItem', item, price)
 end)
-
-RegisterNetEvent("vendingitem2")
-AddEventHandler("vendingitem2", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
-    Citizen.Wait(2000)
-    ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","donut",5)
-end)
-
-RegisterNetEvent("vendingitem3")
-AddEventHandler("vendingitem3", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
-    Citizen.Wait(2000)
-    ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","banana",5)
-end)
-
---Вендинг
-
-RegisterNetEvent("sodaitem1")
-AddEventHandler("sodaitem1", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
-    Citizen.Wait(2000)
-    ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","water",5)
-    
-    
-end)
-
-RegisterNetEvent("sodaitem2")
-AddEventHandler("sodaitem2", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
-    Citizen.Wait(2000)
-    ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","cocacola",5)
-end)
-
-RegisterNetEvent("sodaitem3")
-AddEventHandler("sodaitem3", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
-    Citizen.Wait(2000)
-    ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","energy",5)
-end)
-
---
-
-RegisterNetEvent("coffeeitem")
-AddEventHandler("coffeeitem", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
-    Citizen.Wait(2000)
-    ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","coffee",5)
-end)
-
-RegisterNetEvent("wateritem")
-AddEventHandler("wateritem", function()
-    TaskPlayAnim(player, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0, -1.0, -1, 1, 0, false, false, false)
-    Citizen.Wait(2000)
-    ClearPedTasksImmediately(player)
-    TriggerServerEvent("mr-vending:server:check","water", 5)
-end)
-
-
-
-
-
-

--- a/config.lua
+++ b/config.lua
@@ -1,3 +1,56 @@
 Config = {}
 
 Config.Target = "qtarget"
+
+Config.Machines = {
+    drinks = {
+        label = "Напитки",
+        icon = "fas fa-glass-whiskey",
+        models = {
+            `prop_vend_soda_01`,
+            `prop_vend_soda_02`,
+            `prop_vend_water_01`,
+        },
+        items = {
+            {label = "Количка", item = "cocacola", price = 7},
+            {label = "Водичка", item = "water", price = 5},
+            {label = "Енергийна напитка", item = "energy", price = 12},
+        }
+    },
+    food = {
+        label = "Вендинг машина",
+        icon = "fas fa-hotdog",
+        models = {
+            `prop_vend_snak_01`,
+            `prop_vend_snak_01_tu`,
+        },
+        items = {
+            {label = "Пакетиран сандвич", item = "sandwich", price = 5},
+            {label = "Фафла", item = "donut", price = 5},
+            {label = "Сливенска поничка", item = "banana", price = 5},
+        }
+    },
+    coffee = {
+        label = "Кафе машина",
+        icon = "fas fa-mug-hot",
+        models = {
+            `prop_vend_coffe_01`,
+        },
+        items = {
+            {label = "Кафенце", item = "coffee", price = 5},
+        }
+    },
+    water = {
+        label = "Диспенсер за вода",
+        icon = "fas fa-water",
+        models = {
+            `prop_watercooler_dark`,
+            `prop_watercooler`,
+            `watercooler_bottle001`,
+            `prop_vend_water_01`,
+        },
+        items = {
+            {label = "Водичка", item = "water", price = 5},
+        }
+    }
+}

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,11 +4,14 @@ game 'gta5'
 
 version '1.0.0'
 
-server_scripts {
-    'server/sv_main.lua'
+shared_scripts {
+    'config.lua'
 }
 
 client_scripts {
-	'client/*.lua',
-    'config.lua'
+    'client/*.lua'
+}
+
+server_scripts {
+    'server/sv_main.lua'
 }

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -1,25 +1,32 @@
---SERVER
+-- SERVER
 ESX = nil
-
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
-RegisterServerEvent("mr-vending:server:check")
-AddEventHandler("mr-vending:server:check", function(item,price)
+local function isValidPurchase(item, price)
+    for _, machine in pairs(Config.Machines) do
+        for _, v in ipairs(machine.items) do
+            if v.item == item and v.price == price then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+RegisterServerEvent('mr-vending:server:buyItem')
+AddEventHandler('mr-vending:server:buyItem', function(item, price)
     local src = source
     local xPlayer = ESX.GetPlayerFromId(src)
-    if  xPlayer.canCarryItem(item, 1) and xPlayer.getMoney() >= price then 
+    if not xPlayer or not isValidPurchase(item, price) then return end
+
+    if xPlayer.canCarryItem(item, 1) and xPlayer.getMoney() >= price then
         xPlayer.addInventoryItem(item, 1)
         xPlayer.removeMoney(price)
-        TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'inform', text = 'Вадиш колата от машината'})
+        TriggerClientEvent('mythic_notify:client:SendAlert', src, { type = 'inform', text = 'Вадиш колата от машината'})
     elseif xPlayer.getMoney() < price then
-        TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'Стотинките не стигнаха, брат!'})
+        TriggerClientEvent('mythic_notify:client:SendAlert', src, { type = 'error', text = 'Стотинките не стигнаха, брат!'})
     elseif not xPlayer.canCarryItem(item, 1) then
-        TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'Джобчетата са ти пълни! Метни нещо'})
+        TriggerClientEvent('mythic_notify:client:SendAlert', src, { type = 'error', text = 'Джобчетата са ти пълни! Метни нещо'})
     end
 end)
-
-
-
-
-


### PR DESCRIPTION
## Summary
- redesign config with machine types and items
- simplify client logic using loops and single buy event
- verify purchases server-side using config
- share config via fxmanifest

## Testing
- `luacheck *.lua */*.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554077e0c8833391117b9d34ac3f0e